### PR TITLE
特定の環境でlibv8がコンパイルできない問題を解消

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ GEM
       thor (>= 0.14, < 2.0)
     json (1.8.2)
     jwt (1.4.1)
-    libv8 (3.16.14.7)
+    libv8 (3.16.14.13)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     mime-types (2.5)
@@ -198,3 +198,6 @@ DEPENDENCIES
   therubyracer
   uglifier (>= 1.3.0)
   will_paginate
+
+BUNDLED WITH
+   1.11.2


### PR DESCRIPTION
[この問題](http://qiita.com/ganta/items/53f616b48e94d989952f)を解消
